### PR TITLE
Add virtual.alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+## Version 0.0.2
+
+- Add optional domain alias, so alias will redirect to the main host
 
 ## Version 0.0.1
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ services:
     image: "katacoda/docker-http-server:v2"
     labels:
       - "virtual.host=myapp.com"  # your domain
+      - "virtual.alias=www.myapp.com"  # alias for your domain (optional)
       - "virtual.port=80"  # exposed port of this container
       - "virtual.tls-email=admin@myapp.com"  # ssl is now on
 ```
@@ -58,6 +59,7 @@ Then, every container represents a single `upstream` to serve requests.
 
 There are several options to configure:
 - `virtual.host` is basically a domain name, see [`Caddy` docs](https://caddyserver.com/docs/proxy)
+- `virtual.alias` (optional) domain alias, useful for `www` prefix with redirect. For example `www.myapp.com`. Alias will always redirect to the host above.
 - `virtual.port` exposed port of the container
 - `virtual.tls_email` could be empty, unset or set to [valid email](https://caddyserver.com/docs/tls)
 

--- a/docker-gen/templates/Caddyfile.tmpl
+++ b/docker-gen/templates/Caddyfile.tmpl
@@ -10,11 +10,19 @@ errors stderr
 
 {{ range $h, $containers := $hosts }}
 {{ $c := first $containers }}
-{{ $host := index $c.Labels "virtual.host" }}
+{{ $host := trim (index $c.Labels "virtual.host") }}
 {{ $tlsEnv := trim (index $c.Labels "virtual.tls-email") }}
 {{ $tlsOff := eq $tlsEnv "" }}
+{{ $alias := trim (index $c.Labels "virtual.alias") }}
+{{ $aliasPresent := ne $alias "" }}
 
-{{ if $tlsOff }}http://{{ end }}{{ trim $host }} {
+{{ if $aliasPresent  }}
+{{ if $tlsOff }}http://{{ end }}{{ $alias }} {
+  redir {{ if $tlsOff }}http://{{ else }}https://{{ end }}{{ $host }}
+}
+{{ end }}
+
+{{ if $tlsOff }}http://{{ end }}{{ $host }} {
   tls {{ if $tlsOff }}off{{ else }}{{ $tlsEnv }}{{ end }}
 
   proxy / {


### PR DESCRIPTION
How to test:

Build container:

```
docker build -t caddy-gen-dev .
```

Create empty directory and have a `docker-compose.yml` file:

```
version: "3"
services:
  caddy-gen:
    container_name: caddy-gen
    image: "caddy-gen-dev:latest" # IMPORTANT
    restart: always
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro  # needs socket to read events
      - ./certs/acme:/etc/caddy/acme  # to save acme
      - ./certs/ocsp:/etc/caddy/ocsp  # to save certificates
    ports:
      - "80:80"
      # - "443:443"
    depends_on:
      - whoami

  whoami:  # this is your service
    image: "katacoda/docker-http-server:v2"
    labels:
      - "virtual.host=myapp.com"  # your domain
      - "virtual.port=80"  # exposed port of this container
      - "virtual.alias=www.myapp.com"
      # - "virtual.tls-email=admin@myapp.com"  # ssl is now on
```

Run:

```
docker-compose up
```

Output:

```
Pulling whoami (katacoda/docker-http-server:v2)...
v2: Pulling from katacoda/docker-http-server
6351927607c9: Pull complete
Digest: sha256:f0985b2504a77c0cb42b6989ac951084f4557ec03727af89049afaccf7370bba
Creating caddygenexample_whoami_1    ... done
Creating caddy-gen ... done
Creating caddy-gen ... 
Attaching to caddygenexample_whoami_1, caddy-gen
whoami_1     | Web Server started. Listening on 0.0.0.0:80
caddy-gen    | 2018/02/06 00:21:47 Generated '/etc/caddy/Caddyfile' from 2 containers
caddy-gen    | forego     | starting dockergen.1 on port 5000
caddy-gen    | forego     | starting caddy.1 on port 5100
caddy-gen    | caddy.1    | Activating privacy features... done.
caddy-gen    | caddy.1    | http://www.myapp.com
caddy-gen    | caddy.1    | 2018/02/06 00:21:47 http://www.myapp.com
caddy-gen    | caddy.1    | http://myapp.com
caddy-gen    | dockergen.1 | 2018/02/06 00:21:47 Contents of /etc/caddy/Caddyfile did not change. Skipping notification ''
caddy-gen    | dockergen.1 | 2018/02/06 00:21:47 Watching docker events
caddy-gen    | dockergen.1 | 2018/02/06 00:21:47 Contents of /etc/caddy/Caddyfile did not change. Skipping notification ''
caddy-gen    | caddy.1    | 2018/02/06 00:23:01 [INFO] localhost - No such site at :80 (Remote: 172.19.0.1, Referer: )
caddy-gen    | caddy.1    | 172.19.0.1 - - [06/Feb/2018:00:24:02 +0000] "GET / HTTP/1.1" 200 79
caddy-gen    | caddy.1    | 172.19.0.1 - - [06/Feb/2018:00:24:46 +0000] "GET / HTTP/1.1" 200 79
^CGracefully stopping... (press Ctrl+C again to force)
Stopping caddy-gen                ... done
Stopping caddygenexample_whoami_1 ... done
```

^ www is there, which is good. Let's examine Caddyfile (`61d1792bcc11` is container name you get with `docker ps`):

```
$ docker exec -it 61d1792bcc11 "/bin/bash"
# cat /etc/caddy/Caddyfile
http://www.myapp.com {
  redir http://myapp.com
}
http://myapp.com {
  tls off
  proxy / {
    policy round_robin
    transparent
    upstream 172.19.0.2:80
  }
  gzip
  log stdout
  errors stderr
}
```

Which is nice, let's check with curl:

```
$ curl -H 'Host: myapp.com' -v http://127.0.0.1:80 
* Rebuilt URL to: http://127.0.0.1:80/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: myapp.com
> User-Agent: curl/7.50.2
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 79
< Content-Type: text/html; charset=utf-8
< Date: Tue, 06 Feb 2018 00:24:46 GMT
< Server: Caddy
< 
<h1>New Release! Now v2! This request was processed by host: cd06a0fb687d</h1>
* Curl_http_done: called premature == 0
* Connection #0 to host 127.0.0.1 left intact
```

And with prefix:

```
curl -H 'Host: www.myapp.com' -v http://127.0.0.1:80
* Rebuilt URL to: http://127.0.0.1:80/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: www.myapp.com
> User-Agent: curl/7.50.2
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Location: http://myapp.com
< Server: Caddy
< Date: Tue, 06 Feb 2018 00:24:36 GMT
< Content-Length: 51
< Content-Type: text/html; charset=utf-8
< 
<a href="http://myapp.com">Moved Permanently</a>.

* Curl_http_done: called premature == 0
* Connection #0 to host 127.0.0.1 left intact
```  

Nice, we have redirect.

myapp.com -> www.myapp.com tests:

```
$ curl -H 'Host: myapp.com' -v http://127.0.0.1:80
* Rebuilt URL to: http://127.0.0.1:80/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: myapp.com
> User-Agent: curl/7.50.2
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Location: http://www.myapp.com
< Server: Caddy
< Date: Tue, 06 Feb 2018 00:34:38 GMT
< Content-Length: 55
< Content-Type: text/html; charset=utf-8
< 
<a href="http://www.myapp.com">Moved Permanently</a>.

* Curl_http_done: called premature == 0
* Connection #0 to host 127.0.0.1 left intact

```

and

```
$ curl -H 'Host: www.myapp.com' -v http://127.0.0.1:80
* Rebuilt URL to: http://127.0.0.1:80/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: www.myapp.com
> User-Agent: curl/7.50.2
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 79
< Content-Type: text/html; charset=utf-8
< Date: Tue, 06 Feb 2018 00:34:45 GMT
< Server: Caddy
< 
<h1>New Release! Now v2! This request was processed by host: cd7b88b8c7f4</h1>
* Curl_http_done: called premature == 0
* Connection #0 to host 127.0.0.1 left intact
```

I think it should also work with https. Let's merge and deploy and then test if it works maybe?

