### PR TITLE
Adding support for having several host(names)

### DIFF
--- a/docker-gen/templates/Caddyfile.tmpl
+++ b/docker-gen/templates/Caddyfile.tmpl
@@ -10,7 +10,8 @@ errors stderr
 
 {{ range $h, $containers := $hosts }}
 {{ $c := first $containers }}
-{{ $host := trim (index $c.Labels "virtual.host") }}
+{{ $allhosts := trim (index $c.Labels "virtual.host") }}
+{{ range $t, $host := split $allhosts " " }}
 {{ $tlsEnv := trim (index $c.Labels "virtual.tls-email") }}
 {{ $tlsOff := eq $tlsEnv "" }}
 {{ $alias := trim (index $c.Labels "virtual.alias") }}
@@ -41,6 +42,7 @@ errors stderr
   log stdout
   errors stderr
 }
+{{ end }}
 {{ end }}
 
 {{ end }}


### PR DESCRIPTION
This makes it possible to specify labels such as

```
virtual.host=myapp.com example.com
```

and will arrange for all of these hosts to point towards the service. In practice, the implementation adds a loop in the template, after the value of the host label has been split on space.