### PR TITLE
Add `tls` label (alias of `tls-email`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ There are several options to configure:
 - `virtual.host` is basically a domain name, see [`Caddy` docs](https://caddyserver.com/docs/proxy)
 - `virtual.alias` (optional) domain alias, useful for `www` prefix with redirect. For example `www.myapp.com`. Alias will always redirect to the host above.
 - `virtual.port` exposed port of the container
-- `virtual.tls_email` could be empty, unset or set to [valid email](https://caddyserver.com/docs/tls)
+- `virtual.tls-email` could be empty, unset or set to [valid email](https://caddyserver.com/docs/tls)
+- `virtual.tls` (alias of `virtual.tls-email`) could be empty, unset or set to a [valid set of tls directive value(s)](https://caddyserver.com/docs/tls)
 - `virtual.websocket` when set, enables websocket connection passthrough
 
 Note, that options should not differ for containers of a single service.

--- a/docker-gen/templates/Caddyfile.tmpl
+++ b/docker-gen/templates/Caddyfile.tmpl
@@ -12,7 +12,9 @@ errors stderr
 {{ $c := first $containers }}
 {{ $allhosts := trim (index $c.Labels "virtual.host") }}
 {{ range $t, $host := split $allhosts " " }}
-{{ $tlsEnv := trim (index $c.Labels "virtual.tls-email") }}
+{{ $tlsEmail := trim (index $c.Labels "virtual.tls-email") }}
+{{ $tlsConfig := trim (index $c.Labels "virtual.tls") }}
+{{ $tlsEnv := or $tlsEmail $tlsConfig }}
 {{ $tlsOff := eq $tlsEnv "" }}
 {{ $alias := trim (index $c.Labels "virtual.alias") }}
 {{ $aliasPresent := ne $alias "" }}
@@ -30,7 +32,7 @@ errors stderr
     policy round_robin
     transparent
     {{ if contains $c.Labels "virtual.websockets" }}websocket{{ end }}
-    
+
     {{ range $i, $container := $containers }}
     {{ range $j, $net := $container.Networks }}
     {{ $port := index $container.Labels "virtual.port" }}


### PR DESCRIPTION
Closes https://github.com/wemake-services/caddy-gen/issues/18

- adds a `tls` label (that gets injected as the `tls` value if `tls-email` is not set)
- update the docs

How to test:

Build container:

```
docker build -t caddy-gen-dev .
```

Create empty directory and have a `docker-compose.yml` file:

```
version: "3"
services:
  caddy-gen:
    container_name: caddy-gen
    image: "caddy-gen-dev:latest" # IMPORTANT
    restart: always
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro  # needs socket to read events
      - ./certs/acme:/etc/caddy/acme  # to save acme
      - ./certs/ocsp:/etc/caddy/ocsp  # to save certificates
    ports:
      - "80:80"
      - "443:443"
    depends_on:
      - whoami

  whoami:  # this is your service
    image: "katacoda/docker-http-server:v2"
    labels:
      - "virtual.host=myapp.com"  # your domain
      - "virtual.port=80"  # exposed port of this container
      - "virtual.tls=admin@myapp.com"  # ssl is now on
```

Run:

```
docker-compose up
```

Output:

```
Creating test-caddy-gen-patch_whoami_1 ... done
Creating caddy-gen                     ... done
whoami_1     | Web Server started. Listening on 0.0.0.0:80
caddy-gen    | 2019/03/10 19:02:33 Generated '/etc/caddy/Caddyfile' from 2 containers
caddy-gen    | forego     | starting dockergen.1 on port 5000
caddy-gen    | forego     | starting caddy.1 on port 5100
caddy-gen    | dockergen.1 | 2019/03/10 19:02:33 Contents of /etc/caddy/Caddyfile did not change. Skipping notification ''
caddy-gen    | dockergen.1 | 2019/03/10 19:02:33 Watching docker events
caddy-gen    | dockergen.1 | 2019/03/10 19:02:34 Contents of /etc/caddy/Caddyfile did not change. Skipping notification ''
caddy-gen    | caddy.1    | Activating privacy features... 2019/03/10 19:02:34 [INFO] acme: Registering account for admin@myapp.com
```

Caddy attempted to create certificates with `admin@myapp.com`, which means `virtual.tls` gets injected as the `tls` directive value.

Alternatively, could attempt to use https://github.com/HugoDF/docker-compose-local-https/tree/master/caddy-gen, switch out the image at https://github.com/HugoDF/docker-compose-local-https/blob/master/caddy-gen/docker-compose.yml#L4 for `caddy-gen-dev:latest` and switch `virtual.tls-email` for `virtual.tls`.