### PR TITLE
Bump Caddy version from 0.10.11 to 0.10.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Nikita Sobolev <sobolevn@wemake.services>"
 LABEL vendor="wemake.services"
 LABEL version="0.1.0"
 
-ARG CADDY_VERSION="0.10.11"
+ARG CADDY_VERSION="0.10.12"
 ARG FOREGO_VERSION="0.16.1"
 ARG DOCKER_GEN_VERSION="0.7.4"
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 dockergen: docker-gen -watch -notify "pkill -USR1 caddy" -config /code/docker-gen/config/docker-gen.cfg
-caddy: caddy --conf /etc/caddy/Caddyfile --log stdout
+caddy: caddy --conf /etc/caddy/Caddyfile --log stdout --agree=true


### PR DESCRIPTION
Closes #25 

ACMEv1 was deprecated on Nov. 8 2019, and Caddy 0.10.12 is required to use v2.
This change also passes the explicit consent option for Let's Encrypt to Caddy (required).