### PR TITLE
File server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Options to configure:
 
 Password should be a string `base64` encoded from `bcrypt` hash. You can use https://bcrypt-generator.com/ with default config and https://www.base64encode.org/.
 
+Static file server options (see [Caddy file_server docs](https://caddyserver.com/docs/caddyfile/directives/file_server#syntax)):
+- `virtual.static.root`
+- `virtual.static.matcher` 
+- `virtual.static.hide`
+- `virtual.static.index`
+- `virtual.static.browse` enabled if "true", otherwise disabled
+- `virtual.noProxy` when "true", disable reverse proxy for the domain, useful
+  when domain only serves static files. Otherwise, use
+- `virtual.proxy.matcher` to route certain paths to the proxy, such as `/api/*`
+
 ## Backing up certificates
 
 To backup certificates make a volume:
@@ -72,7 +82,7 @@ services:
       - "virtual.alias=www.myapp.com" # alias for your domain (optional)
       - "virtual.port=80" # exposed port of this container
       - "virtual.tls-email=admin@myapp.com" # ssl is now on
-      - "virtual.auth.path=/secret/*" # path basic authnetication applys to
+      - "virtual.auth.path=/secret/*" # path basic authentication applies to
       - "virtual.auth.username=admin" # Optionally add http basic authentication
       - "virtual.auth.password=JDJ5JDEyJEJCdzJYM0pZaWtMUTR4UVBjTnRoUmVJeXQuOC84QTdMNi9ONnNlbDVRcHltbjV3ME1pd2pLCg==" # By specifying both username and password hash
 ```
@@ -96,7 +106,7 @@ There are several options to configure:
 - `virtual.tls` (alias of `virtual.tls-email`) could be empty, unset or set to a [valid set of tls directive value(s)](https://caddyserver.com/docs/caddyfile/directives/tls)
 - `virtual.auth.username` when set, along with `virtual.auth.password` and `virtual.auth.path`, http basic authentication is enabled
 - `virtual.auth.password` needs to be specified, along with `virtual.auth.usernmae`, to enable http [basic authentication](https://caddyserver.com/docs/caddyfile/directives/basicauth)
-- `virtual.auth.path` sets path basic auth applys to.
+- `virtual.auth.path` sets path basic auth applies to.
 
 Note, that options should not differ for containers of a single service.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
     depends_on:
       - whoami
       - whoami2
+    labels:
+      - "virtual.host=static-1.localhost static-2.localhost"
+      - "virtual.static.root=/usr/share/caddy/"
+      - "virtual.noProxy=true"
 
   whoami:
     image: "katacoda/docker-http-server:v1"

--- a/docker-gen/templates/Caddyfile.tmpl
+++ b/docker-gen/templates/Caddyfile.tmpl
@@ -25,6 +25,13 @@ log {
 {{ $authPassword := trim (index $c.Labels "virtual.auth.password") }}
 {{ $authPath := trim (index $c.Labels "virtual.auth.path") }}
 {{ $basicauth := and (ne $authUsername "") (ne $authPassword "") }}
+{{ $staticRoot := trim (index $c.Labels "virtual.static.root") }}
+{{ $staticMatcher := trim (index $c.Labels "virtual.static.matcher") }}
+{{ $staticHide := trim (index $c.Labels "virtual.static.hide") }}
+{{ $staticIndex := trim (index $c.Labels "virtual.static.index") }}
+{{ $staticBrowse := trim (index $c.Labels "virtual.static.browse") }}
+{{ $noProxy := eq (trim (index $c.Labels "virtual.noProxy")) "true" }}
+{{ $proxyMatcher := trim (index $c.Labels "virtual.proxy.matcher") }}
 
 {{ if $aliasPresent  }}
 {{ if $tlsOff }}http://{{ end }}{{ $alias }} {
@@ -40,7 +47,19 @@ log {
       {{ $authUsername }} {{ $authPassword }}
   }
   {{ end }}
-  reverse_proxy {
+
+  {{ if ne $staticRoot "" }}
+  root * {{ $staticRoot }}
+  templates
+  file_server {{ $staticMatcher }} {
+    {{ if ne $staticHide "" }}hide {{ $staticHide }}{{ end }}
+    {{ if ne $staticIndex "" }}index {{ $staticIndex }}{{ end }}
+    {{ if ne $staticBrowse "" }}browse{{ end }}
+  }
+  {{ end }}
+
+  {{ if not $noProxy }}
+  reverse_proxy {{ $proxyMatcher }} {
     lb_policy round_robin
     {{ range $i, $container := $containers }}
     {{ range $j, $net := $container.Networks }}
@@ -49,6 +68,7 @@ log {
     {{ end }}
     {{ end }}
   }
+  {{ end }}
 
   encode zstd gzip
   log {


### PR DESCRIPTION
Added options to specify a static file server, I found it useful when I didn't want to set up a separate container for a static file server on the same host I was using caddy-gen. So I added some options to take advantage of Caddy's existing static file_server capabilities. Let me know if you find this useful, I realize it's not super configurable because you can't add cache control headers and other things.

For explanation of options, see edits to README, and for example usage, see edits to docker-compose.yml