### PR TITLE
fix: Caddy2 doesn't respond to USR1 signal. Fixes #40.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 dockergen: docker-gen -watch -config /code/docker-gen/config/docker-gen.cfg
-caddy: caddy start -config /etc/caddy/Caddyfile --watch
+caddy: caddy start --config /etc/caddy/Caddyfile --watch

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-dockergen: docker-gen -watch -notify "pkill -USR1 caddy" -config /code/docker-gen/config/docker-gen.cfg
+dockergen: docker-gen -watch -config /code/docker-gen/config/docker-gen.cfg
 caddy: caddy start -config /etc/caddy/Caddyfile --watch


### PR DESCRIPTION
fixes #40, caddy should reload because it is being run with the `--watch` flag and docker-gen is writing to `/etc/caddy/Caddyfile`