### PR TITLE
Rename directive basicauth to basic_auth

### DIFF
--- a/docker-gen/templates/Caddyfile.tmpl
+++ b/docker-gen/templates/Caddyfile.tmpl
@@ -46,7 +46,7 @@
   {{ if $hostImport }}import {{ $hostImport }}{{ end }}
 
   {{ if $basicauth }}
-  basicauth {{ $authPath }} {
+  basic_auth {{ $authPath }} {
       {{ $authUsername }} {{ $authPassword }}
   }
   {{ end }}


### PR DESCRIPTION
https://caddyserver.com/docs/caddyfile/directives/basic_auth
Prior to v2.8.0, this directive was named `basicauth`, but was renamed for consistency with other directives.

Using `basicauth` spam to log:
```
{"level":"warn","ts":1742152621.2904515,"logger":"config.adapter.caddyfile","msg":"the 'basicauth' directive is deprecated, please use 'basic_auth' instead!"}
```